### PR TITLE
Allow for the CRS and default extent of the generated project to be specified

### DIFF
--- a/xlsformconverter/XLSFormConverter.py
+++ b/xlsformconverter/XLSFormConverter.py
@@ -85,6 +85,7 @@ class XLSFormConverter(QObject):
     preferred_language = None
     basemap = None
     crs = QgsCoordinateReferenceSystem("EPSG:3857")
+    extent = QgsRectangle()
     geometries = None
     groups_as_tabs = False
 
@@ -1020,7 +1021,13 @@ class XLSFormConverter(QObject):
         self.basemap = basemap
 
     def set_crs(self, crs):
-        self.crs = crs
+        if crs.isValid():
+            self.crs = crs
+        else:
+            self.crs = QgsCoordinateReferenceSystem("EPSG:3857")
+
+    def set_extent(self, extent):
+        self.extent = extent
 
     def set_geometries(self, geometries):
         self.geometries = geometries
@@ -1647,7 +1654,9 @@ class XLSFormConverter(QObject):
                     )
                 )
 
-        if survey_extent:
+        if not self.extent.isEmpty():
+            survey_extent = self.extent
+        elif survey_extent:
             transform = QgsCoordinateTransform(
                 current_layer[0].crs(),
                 self.output_project.crs(),
@@ -1676,8 +1685,6 @@ class XLSFormConverter(QObject):
                 survey_extent = None
 
         if not survey_extent:
-            print("...")
-            print(self.output_project.crs().authid())
             if self.output_project.crs().authid() == "EPSG:3857":
                 survey_extent = QgsRectangle(-9.88, 33.41, 40.97, 61.11)
             else:
@@ -1710,10 +1717,7 @@ class XLSFormConverter(QObject):
                 self.output_project.crs(),
                 self.output_project.transformContext(),
             )
-            print(survey_extent)
             survey_extent = transform.transformBoundingBox(survey_extent)
-            print(survey_extent)
-            print("---")
 
         self.output_extent = survey_extent
 

--- a/xlsformconverter/XLSFormConverterAlgorithms.py
+++ b/xlsformconverter/XLSFormConverterAlgorithms.py
@@ -4,6 +4,7 @@ from qgis.core import (
     QgsProcessing,
     QgsProcessingAlgorithm,
     QgsProcessingParameterBoolean,
+    QgsProcessingParameterCrs,
     QgsProcessingParameterDefinition,
     QgsProcessingParameterEnum,
     QgsProcessingParameterFeatureSource,
@@ -35,6 +36,7 @@ class XLSFormConverterAlgorithm(QgsProcessingAlgorithm):
     BASEMAP = "BASEMAP"
     GROUPS_AS_TABS = "GROUPS_AS_TABS"
     UPLOAD_TO_QFIELDCLOUD = "UPLOAD_TO_QFIELDCLOUD"
+    CRS = "CRS"
     GEOMETRIES = "GEOMETRIES"
     OUTPUT = "OUTPUT"
 
@@ -123,6 +125,14 @@ class XLSFormConverterAlgorithm(QgsProcessingAlgorithm):
         param.setFlags(param.flags() | QgsProcessingParameterDefinition.Flag.Advanced)
         self.addParameter(param)
 
+        param = QgsProcessingParameterCrs(
+            self.CRS,
+            self.tr("Project CRS"),
+            optional=True,
+        )
+        param.setFlags(param.flags() | QgsProcessingParameterDefinition.Flag.Advanced)
+        self.addParameter(param)
+
         param = QgsProcessingParameterFeatureSource(
             self.GEOMETRIES,
             self.tr(
@@ -145,6 +155,7 @@ class XLSFormConverterAlgorithm(QgsProcessingAlgorithm):
         xlsform_file = self.parameterAsString(parameters, self.INPUT, context)
         title = self.parameterAsString(parameters, self.TITLE, context)
         language = self.parameterAsString(parameters, self.LANGUAGE, context)
+        crs = self.parameterAsCrs(parameters, self.CRS, context)
         geometries = self.parameterAsSource(parameters, self.GEOMETRIES, context)
 
         basemap = "OpenStreetMap"
@@ -174,6 +185,8 @@ class XLSFormConverterAlgorithm(QgsProcessingAlgorithm):
         converter.set_basemap(basemap)
         converter.set_geometries(geometries)
         converter.set_groups_as_tabs(groups_as_tabs)
+        if crs.isValid():
+            converter.set_crs(crs)
 
         project_file = converter.convert(output_directory)
 

--- a/xlsformconverter/XLSFormConverterAlgorithms.py
+++ b/xlsformconverter/XLSFormConverterAlgorithms.py
@@ -111,19 +111,19 @@ class XLSFormConverterAlgorithm(QgsProcessingAlgorithm):
 
         self.addParameter(
             QgsProcessingParameterBoolean(
+                self.GROUPS_AS_TABS,
+                self.tr("Use form tabs for root groups"),
+                defaultValue=False,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterBoolean(
                 self.UPLOAD_TO_QFIELDCLOUD,
                 self.tr("Upload generated project to QFieldCloud"),
                 defaultValue=False,
             )
         )
-
-        param = QgsProcessingParameterBoolean(
-            self.GROUPS_AS_TABS,
-            self.tr("Serve root groups as feature form tabs"),
-            defaultValue=False,
-        )
-        param.setFlags(param.flags() | QgsProcessingParameterDefinition.Flag.Advanced)
-        self.addParameter(param)
 
         param = QgsProcessingParameterCrs(
             self.CRS,


### PR DESCRIPTION
Implements enhancement request filed here (https://github.com/opengisch/XLSFormConverter/issues/9). A new parameter found in the advanced settings group box allows for users to pick a CRS to set the generated project to. 

<img width="681" height="803" alt="image" src="https://github.com/user-attachments/assets/6e3c7b01-a09e-46e5-830f-3df655b952c5" />

If the generated project has features, the combined extent of those feature geometries will be used as default extent. If the project is empty, a default extent derived from the picked CRS' bounds will be generated. 

In addition, a new extent parameter was added to set a custom default extent when opening the generated project. This can come in handy in models and scripts using the converter to create surveys where features are not yet added but where the area of interest is already known.