### PR TITLE
Add `hasProcessingProvider` to metadata.txt

### DIFF
--- a/xlsformconverter/metadata.txt
+++ b/xlsformconverter/metadata.txt
@@ -33,3 +33,4 @@ icon=icon.svg
 
 experimental=False
 deprecated=False
+hasProcessingProvider=True


### PR DESCRIPTION
- I was loading the plugin for headless pyqgis usage & debugging why I couldn't register the provider (finally got it to work, my fault!)
- While doing that, I saw this param a few times in `metadata.txt`: `hasProcessingProvider`.
- https://docs.qgis.org/3.40/en/docs/pyqgis_developer_cookbook/plugins/plugins.html
- I don't know if it's purely informational, or actually determines how the plugin is loaded somehow, but I thought it would be good to have regardless.