### PR TITLE
Digitize by default in QField

### DIFF
--- a/xlsformconverter/XLSFormConverter.py
+++ b/xlsformconverter/XLSFormConverter.py
@@ -1721,6 +1721,9 @@ class XLSFormConverter(QObject):
 
         self.output_extent = survey_extent
 
+        # Set QField state to digitize when first opening the generated project
+        self.output_project.writeEntry("qfieldsync", "initialMapMode", "digitize")
+
         if self.output_project.crs().authid() == "EPSG:3857":
             # Display coordinates in WGS84 to provide a more useful experience for the average person
             self.output_project.displaySettings().setCoordinateType(


### PR DESCRIPTION
Let's leverage a nice new feature in QField 4.0 which allows us to set digitizing mode on by default when opening new projects. Surveys feel like an ideal scenario for that :)