### PR TITLE
Make using the plugin `qgis_process` CLI-ready

### DIFF
--- a/xlsformconverter/XLSFormConverterPlugin.py
+++ b/xlsformconverter/XLSFormConverterPlugin.py
@@ -56,6 +56,9 @@ class XLSFormConverterPlugin:
         self.provider = XLSFormConverterProvider(self.iface)
 
     def initGui(self):
+        self.initProcessing()
+
+    def initProcessing(self):
         QgsApplication.processingRegistry().addProvider(self.provider)
 
     def unload(self):


### PR DESCRIPTION
Before the CLI was failing with:

```
$ qgis_process run xlsformconverter:xlsformconverter # [...]
QSocketNotifier: Can only be used with threads started with QThread
NoneType: None

error starting plugin: xlsformconverter_local

NoneType: None

error starting plugin: xlsformconverter_old

Algorithm xlsformconverter:xlsformconverter not found!
```