### PR TITLE
Move the about metadata to the previous line, so `qgis-plugin-ci` accepts it now

### DIFF
--- a/xlsformconverter/metadata.txt
+++ b/xlsformconverter/metadata.txt
@@ -8,8 +8,7 @@ version=dev
 author=OPENGIS.ch
 email=info@opengis.ch
 
-about=
-    XLSForm is a form standard created to help simplify the authoring of forms using a spreadsheet program such as LibreOffice Calc or Microsoft Excel. They are simple to get started with but allow for the authoring of complex forms by someone familiar with the syntax.
+about=XLSForm is a form standard created to help simplify the authoring of forms using a spreadsheet program such as LibreOffice Calc or Microsoft Excel. They are simple to get started with but allow for the authoring of complex forms by someone familiar with the syntax.
 
     The plugin algorithm converts a XLSForm file into a QGIS project containing a survey layer with a feature form reflecting the authored form. This can facilitate the creation of complex feature forms through a simple, well-known format.
 


### PR DESCRIPTION


Fixes:
```
2026-05-19 06:51:23||ERROR||parameters||get_metadata||395||Mandatory key is missing in metadata: about
```